### PR TITLE
Fix path for git repository in rebar.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ MCP enables seamless communication between AI assistants and local services thro
 ```bash
 # Add to your rebar.config deps
 {deps, [
-    {erlmcp, {git, "https://github.com/banyan-platform/erlmcp.git", {branch, "main"}}}
+    {erlmcp, {git, "https://github.com/erlsci/erlmcp.git", {branch, "main"}}}
 ]}.
 
 # Fetch and compile


### PR DESCRIPTION
The description has a link to a non existant git repo, ( "https://github.com/banyan-platform/erlmcp.git ) I have updated this to point to the erlsci repo.